### PR TITLE
Comb sort

### DIFF
--- a/src/main/c/collections/int_array/__str_impl.h
+++ b/src/main/c/collections/int_array/__str_impl.h
@@ -1,0 +1,119 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "collections/int_array/api.h"
+#include "collections/int_array/data.h"
+#include "macro/qualifiers.h"
+
+struct __CharSequenceAndLength {
+    const CharSequence char_sequence;
+    const int length;
+};
+
+struct __IntArrayStrFormat {
+    const struct __CharSequenceAndLength typename;
+    const struct __CharSequenceAndLength separator_1;
+    const struct __CharSequenceAndLength separator_2;
+    const struct __CharSequenceAndLength separator_3;
+    IntArray* _int_array;
+    int _size_length;
+    IntArray* _lengths;
+    int _result_str_length;
+};
+
+__pure__ static struct __IntArrayStrFormat __prepare_format(IntArray* int_array);
+__pure__ static struct __CharSequenceAndLength __init_char_sequence_and_length(const CharSequence char_sequence);
+static void __setup_format(struct __IntArrayStrFormat* format, IntArray* int_array);
+__pure__ static int __count_result_str_length(struct __IntArrayStrFormat format);
+__pure__ static int __sum(int i1, int i2);
+static CharSequence __concat_result_str_and_free_format(struct __IntArrayStrFormat format);
+static void __strcat_ulong(CharSequence dst, unsigned long value, int value_lenght);
+static void __write_elems_in_result_str(CharSequence result_str, struct __IntArrayStrFormat format);
+static void __strcat_int(CharSequence dst, int value, int value_length, struct __CharSequenceAndLength postfix);
+
+__pure__ static CharSequence str(IntArray* self) {
+    return __concat_result_str_and_free_format(__prepare_format(self));
+}
+
+__pure__ static struct __IntArrayStrFormat __prepare_format(IntArray* int_array) {
+    struct __IntArrayStrFormat format = {
+        .typename=__init_char_sequence_and_length("IntArray["),
+        .separator_1=__init_char_sequence_and_length("]{ "),
+        .separator_2=__init_char_sequence_and_length(", "),
+        .separator_3=__init_char_sequence_and_length(" }"),
+    };
+    __setup_format(&format, int_array);
+    return format;
+}
+
+__pure__ static struct __CharSequenceAndLength __init_char_sequence_and_length(const CharSequence char_sequence) {
+    struct __CharSequenceAndLength char_sequence_and_length = {
+        .char_sequence=char_sequence,
+        .length=strlen(char_sequence),
+    };
+    return char_sequence_and_length;
+}
+
+static void __setup_format(struct __IntArrayStrFormat* format, IntArray* int_array) {
+    IntArrayApi* api = int_array_api();
+    format->_int_array = int_array;
+    format->_size_length = snprintf(NULL, 0, "%zu", format->_int_array->_size);
+    IntArray* lengths = api->init();
+    for (int i = 0; i < format->_int_array->_size; ++i) {
+        api->append(lengths, snprintf(NULL, 0, "%d", format->_int_array->_elems[i]));
+    }
+    format->_lengths = lengths;
+    format->_result_str_length = __count_result_str_length(*format);
+}
+
+__pure__ static int __count_result_str_length(struct __IntArrayStrFormat format) {
+    return format.typename.length +
+        format._size_length +
+        format.separator_1.length +
+        int_array_api()->fold(format._lengths, 0, &__sum) +
+        (format.separator_2.length * (format._int_array->_size - 1)) +
+        format.separator_3.length;
+}
+
+__pure__ static int __sum(int i1, int i2) {
+    return i1 + i2;
+}
+
+static CharSequence __concat_result_str_and_free_format(struct __IntArrayStrFormat format) {
+    CharSequence result = calloc(format._result_str_length + 1, sizeof(char));
+    strncat(result, format.typename.char_sequence, format.typename.length + 1);
+    __strcat_ulong(result, format._int_array->_size, format._size_length);
+    strncat(result, format.separator_1.char_sequence, format.separator_1.length + 1);
+    __write_elems_in_result_str(result, format);
+    free(format._lengths);
+    return result;
+}
+
+static void __strcat_ulong(CharSequence dst, unsigned long value, int value_lenght) {
+    CharSequence tmp = calloc(value_lenght + 1, sizeof(char));
+    snprintf(tmp, value_lenght + 1, "%zu", value);
+    strncat(dst, tmp, value_lenght + 1);
+    free(tmp);
+}
+
+static void __write_elems_in_result_str(CharSequence result_str, struct __IntArrayStrFormat format) {
+    int last_elem_index = format._int_array->_size - 1;
+    for (int i = 0; i < last_elem_index; ++i) {
+        __strcat_int(result_str, format._int_array->_elems[i], format._lengths->_elems[i], format.separator_2);
+    }
+    __strcat_int(
+        result_str,
+        format._int_array->_elems[last_elem_index],
+        format._lengths->_elems[last_elem_index],
+        format.separator_3
+    );
+}
+
+static void __strcat_int(CharSequence dst, int value, int value_length, struct __CharSequenceAndLength postfix) {
+    int postfixed_value_length = value_length + postfix.length;
+    CharSequence tmp = calloc(postfixed_value_length + 1, sizeof(char));
+    snprintf(tmp, postfixed_value_length + 1, "%d%s", value, postfix.char_sequence);
+    strncat(dst, tmp, postfixed_value_length + 1);
+    free(tmp);
+}

--- a/src/main/c/collections/int_array/api.h
+++ b/src/main/c/collections/int_array/api.h
@@ -52,9 +52,7 @@ typedef struct IntArrayApi {
 
     IntArray* (*filtered)(IntArray* self, FilterInt filter);
 
-    void (*_swap)(IntArray* self, int i, int j);
-
-    bool (*_should_swap)(IntArray* self, int left_index, int right_index);
+    bool (*__decide_swap)(IntArray* self, int left_index, int right_index);
 
 } IntArrayApi;
 

--- a/src/main/c/collections/int_array/sortings/__bubble_sort_impl.h
+++ b/src/main/c/collections/int_array/sortings/__bubble_sort_impl.h
@@ -21,10 +21,7 @@ static bool _raise_bubble(IntArray* self, int left_elem_in_pair_last_index) {
         left_index < left_elem_in_pair_last_index;
         ++left_index, ++right_index
     ) {
-        bubble_raised |= (
-            int_array_api()->_should_swap(self, left_index, right_index) &&
-            (int_array_api()->_swap(self, left_index, right_index), true)
-        );
+        bubble_raised |= int_array_api()->__decide_swap(self, left_index, right_index);
     }
     return bubble_raised;
 }

--- a/src/main/c/collections/int_array/sortings/__comb_sort_impl.h
+++ b/src/main/c/collections/int_array/sortings/__comb_sort_impl.h
@@ -1,0 +1,17 @@
+#include "collections/int_array/api.h"
+#include "collections/int_array/data.h"
+
+#define COMB_SORT_COEFFICIENT 1.2473309
+
+static void bubble_sort(IntArray* self);
+
+static void comb_sort(IntArray* self) {
+    for (int gap = self->_size - 1; gap > 1; gap /= COMB_SORT_COEFFICIENT) {
+        for (int i = 0; (i + gap) < self->_size; ++i) {
+            int_array_api()->__decide_swap(self, i, i + gap);
+        }
+    }
+    bubble_sort(self);
+}
+
+#undef COMB_SORT_COEFFICIENT

--- a/src/main/c/collections/int_array/sortings/__shaker_sort_impl.h
+++ b/src/main/c/collections/int_array/sortings/__shaker_sort_impl.h
@@ -61,23 +61,16 @@ static bool _shake_with_swaps_folding(struct __ShakerIterator shaker) {
 
 static bool _shake_right_with_swaps_folding(struct __ShakerIterator shaker) {
     bool swapped = false;
-    for (int i = shaker._right_elems_in_pair; i < shaker._left_elems_in_pair; i++) {
-        swapped |= _decide_swap(shaker._int_array, i, i + 1);
+    for (int i = shaker._right_elems_in_pair; i < shaker._left_elems_in_pair; ++i) {
+        swapped |= int_array_api()->__decide_swap(shaker._int_array, i, i + 1);
     }
     return swapped;
 }
 
 static bool _shake_left_with_swaps_folding(struct __ShakerIterator shaker) {
     bool swapped = false;
-    for (int i = shaker._left_elems_in_pair; i > shaker._right_elems_in_pair; i--) {
-        swapped |= _decide_swap(shaker._int_array, i - 1, i);
+    for (int i = shaker._left_elems_in_pair; i > shaker._right_elems_in_pair; --i) {
+        swapped |= int_array_api()->__decide_swap(shaker._int_array, i - 1, i);
     }
     return swapped;
-}
-
-static bool _decide_swap(IntArray* int_array, int left_index, int right_index) {
-    return (
-        int_array_api()->_should_swap(int_array, left_index, right_index) &&
-        (int_array_api()->_swap(int_array, left_index, right_index), true)
-    );
 }

--- a/src/main/c/collections/int_array/sortings/sortings.c
+++ b/src/main/c/collections/int_array/sortings/sortings.c
@@ -3,12 +3,14 @@
 #include "collections/int_array/sortings/sortings.h"
 
 #include "collections/int_array/sortings/__bubble_sort_impl.h"
+#include "collections/int_array/sortings/__comb_sort_impl.h"
 #include "collections/int_array/sortings/__shaker_sort_impl.h"
 
 IntArraySortings* int_array_sortings() {
     static IntArraySortings sortings = {
         .BUBBLE_SORT=bubble_sort,
         .SHAKER_SORT=shaker_sort,
+        .COMB_SORT=comb_sort,
     };
     return &sortings;
 }

--- a/src/main/c/collections/int_array/sortings/sortings.h
+++ b/src/main/c/collections/int_array/sortings/sortings.h
@@ -9,6 +9,8 @@ typedef struct IntArraySortings {
 
     const SortIntArray SHAKER_SORT;
 
+    const SortIntArray COMB_SORT;
+
 } IntArraySortings;
 
 IntArraySortings* int_array_sortings();


### PR DESCRIPTION
* Refactoring: `str` and dependent functions moved to dedicated file; private function `__decide_swap` for usage in sortings, instead of `_swap` and `_should_swap`
* Comb sort implemented